### PR TITLE
feat: implement check_contrast tool with APCA algorithm

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,5 @@
 {
   "permissions": {
-    "allow": [
-      "Bash(gh issue create:*)",
-      "Bash(gh issue edit:*)"
-    ]
+    "allow": ["Bash(gh issue create:*)", "Bash(gh issue edit:*)"]
   }
 }

--- a/src/lib/apca.test.ts
+++ b/src/lib/apca.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import { checkContrast, getMinimumLc } from './apca.js';
+
+describe('checkContrast', () => {
+  describe('basic contrast calculations', () => {
+    it('returns high contrast for black on white', () => {
+      const result = checkContrast('#000000', '#ffffff');
+
+      expect(result.lc).toBeGreaterThan(100);
+      expect(result.passes).toBe(true);
+      expect(result.polarity).toBe('dark-on-light');
+      expect(result.rating).toBe('AAA');
+    });
+
+    it('returns high contrast for white on black (negative Lc)', () => {
+      const result = checkContrast('#ffffff', '#000000');
+
+      expect(result.lc).toBeLessThan(-100);
+      expect(result.lcAbsolute).toBeGreaterThan(100);
+      expect(result.passes).toBe(true);
+      expect(result.polarity).toBe('light-on-dark');
+      expect(result.rating).toBe('AAA');
+    });
+
+    it('returns low contrast for similar colors', () => {
+      const result = checkContrast('#888888', '#999999');
+
+      expect(result.lcAbsolute).toBeLessThan(20);
+      expect(result.passes).toBe(false);
+      expect(result.rating).toBe('fail');
+      expect(result.recommendation).not.toBeNull();
+    });
+
+    it('returns zero or near-zero for identical colors', () => {
+      const result = checkContrast('#808080', '#808080');
+
+      expect(result.lcAbsolute).toBeLessThan(1);
+      expect(result.passes).toBe(false);
+    });
+  });
+
+  describe('color format parsing', () => {
+    it('accepts hex colors with #', () => {
+      const result = checkContrast('#000', '#fff');
+      expect(result.lcAbsolute).toBeGreaterThan(100);
+    });
+
+    it('accepts 6-digit hex colors', () => {
+      const result = checkContrast('#000000', '#ffffff');
+      expect(result.lcAbsolute).toBeGreaterThan(100);
+    });
+
+    it('accepts rgb() format', () => {
+      const result = checkContrast('rgb(0,0,0)', 'rgb(255,255,255)');
+      expect(result.lcAbsolute).toBeGreaterThan(100);
+    });
+
+    it('accepts named colors', () => {
+      const result = checkContrast('black', 'white');
+      expect(result.lcAbsolute).toBeGreaterThan(100);
+    });
+  });
+
+  describe('use case thresholds', () => {
+    it('uses 75 Lc threshold for body text by default', () => {
+      const result = checkContrast('#000000', '#ffffff');
+      expect(result.minimumLc).toBe(75);
+    });
+
+    it('uses 60 Lc threshold for large text', () => {
+      const result = checkContrast('#000000', '#ffffff', {
+        useCase: 'large-text',
+      });
+      expect(result.minimumLc).toBe(60);
+    });
+
+    it('uses 60 Lc threshold for UI components', () => {
+      const result = checkContrast('#000000', '#ffffff', {
+        useCase: 'ui-component',
+      });
+      expect(result.minimumLc).toBe(60);
+    });
+
+    it('uses 45 Lc threshold for placeholders', () => {
+      const result = checkContrast('#000000', '#ffffff', {
+        useCase: 'placeholder',
+      });
+      expect(result.minimumLc).toBe(45);
+    });
+
+    it('uses 45 Lc threshold for disabled states', () => {
+      const result = checkContrast('#000000', '#ffffff', {
+        useCase: 'disabled',
+      });
+      expect(result.minimumLc).toBe(45);
+    });
+  });
+
+  describe('font size and weight adjustments', () => {
+    it('uses 75 Lc for 16px normal body text', () => {
+      const result = checkContrast('#000000', '#ffffff', {
+        fontSize: 16,
+        fontWeight: 'normal',
+        useCase: 'body-text',
+      });
+      expect(result.minimumLc).toBe(75);
+    });
+
+    it('uses 60 Lc for 16px bold body text', () => {
+      const result = checkContrast('#000000', '#ffffff', {
+        fontSize: 16,
+        fontWeight: 'bold',
+        useCase: 'body-text',
+      });
+      expect(result.minimumLc).toBe(60);
+    });
+
+    it('uses 60 Lc for 24px+ text regardless of weight', () => {
+      const result = checkContrast('#000000', '#ffffff', {
+        fontSize: 24,
+        fontWeight: 'normal',
+        useCase: 'body-text',
+      });
+      expect(result.minimumLc).toBe(60);
+    });
+  });
+
+  describe('ratings', () => {
+    it('returns AAA for Lc >= 90', () => {
+      // Black on white gives ~106 Lc
+      const result = checkContrast('#000000', '#ffffff');
+      expect(result.rating).toBe('AAA');
+    });
+
+    it('returns AA for Lc >= 75 and < 90', () => {
+      // #555555 on white gives ~77 Lc
+      const result = checkContrast('#555555', '#ffffff');
+      expect(result.lcAbsolute).toBeGreaterThanOrEqual(75);
+      expect(result.lcAbsolute).toBeLessThan(90);
+      expect(result.rating).toBe('AA');
+    });
+
+    it('returns fail for Lc < 60', () => {
+      // Very low contrast
+      const result = checkContrast('#777777', '#999999');
+      expect(result.lcAbsolute).toBeLessThan(60);
+      expect(result.rating).toBe('fail');
+    });
+  });
+
+  describe('recommendations', () => {
+    it('returns null recommendation when passing', () => {
+      const result = checkContrast('#000000', '#ffffff');
+      expect(result.recommendation).toBeNull();
+    });
+
+    it('provides recommendation when failing', () => {
+      // #777777 on white gives ~71 Lc, which fails body-text (75) but is high enough
+      // to get a helpful "increase contrast" message rather than "too low"
+      const result = checkContrast('#777777', '#ffffff');
+      expect(result.passes).toBe(false);
+      expect(result.recommendation).not.toBeNull();
+      expect(result.recommendation).toContain('Increase contrast');
+    });
+
+    it('warns about very low contrast', () => {
+      const result = checkContrast('#808080', '#858585');
+      expect(result.recommendation).toContain('too low');
+    });
+  });
+});
+
+describe('getMinimumLc', () => {
+  it('returns 75 for body-text at 16px normal', () => {
+    expect(getMinimumLc('body-text', 16, 'normal')).toBe(75);
+  });
+
+  it('returns 60 for body-text at 16px bold', () => {
+    expect(getMinimumLc('body-text', 16, 'bold')).toBe(60);
+  });
+
+  it('returns 60 for body-text at 24px', () => {
+    expect(getMinimumLc('body-text', 24, 'normal')).toBe(60);
+  });
+
+  it('returns threshold directly for non-body-text use cases', () => {
+    expect(getMinimumLc('large-text', 16, 'normal')).toBe(60);
+    expect(getMinimumLc('ui-component', 12, 'normal')).toBe(60);
+    expect(getMinimumLc('placeholder', 14, 'normal')).toBe(45);
+    expect(getMinimumLc('disabled', 14, 'normal')).toBe(45);
+    expect(getMinimumLc('non-text', 16, 'normal')).toBe(45);
+  });
+});

--- a/src/lib/apca.ts
+++ b/src/lib/apca.ts
@@ -1,0 +1,168 @@
+/**
+ * APCA (Accessible Perceptual Contrast Algorithm) utilities
+ *
+ * APCA returns a Lightness Contrast (Lc) value:
+ * - Positive Lc: dark text on light background (BoW - Black on White)
+ * - Negative Lc: light text on dark background (WoB - White on Black)
+ * - Absolute value indicates contrast strength (0-108 range typical)
+ */
+
+// @ts-expect-error - apca-w3 has no type definitions
+import { calcAPCA } from 'apca-w3';
+
+export type UseCase =
+  | 'body-text'
+  | 'large-text'
+  | 'ui-component'
+  | 'non-text'
+  | 'placeholder'
+  | 'disabled';
+
+export type FontWeight = 'normal' | 'bold';
+
+export interface ContrastResult {
+  /** APCA Lightness Contrast value (signed) */
+  lc: number;
+  /** Absolute Lc value */
+  lcAbsolute: number;
+  /** Whether the contrast meets the minimum for the use case */
+  passes: boolean;
+  /** Minimum Lc required for this use case */
+  minimumLc: number;
+  /** Polarity: dark text on light bg, or light text on dark bg */
+  polarity: 'dark-on-light' | 'light-on-dark';
+  /** Human-readable recommendation if failing */
+  recommendation: string | null;
+  /** APCA rating based on absolute Lc */
+  rating: 'AAA' | 'AA' | 'A' | 'fail';
+}
+
+/**
+ * APCA Lc thresholds by use case
+ *
+ * These are conservative minimums based on APCA guidelines.
+ * Higher values are always better for readability.
+ */
+const USE_CASE_THRESHOLDS: Record<UseCase, number> = {
+  'body-text': 75, // 16px normal weight
+  'large-text': 60, // 24px+ or bold
+  'ui-component': 60, // Interactive elements
+  'non-text': 45, // Icons, graphics
+  placeholder: 45, // Placeholder text (with other indicators)
+  disabled: 45, // Disabled states (with other indicators)
+};
+
+/**
+ * Determine minimum Lc based on use case, font size, and weight
+ */
+export function getMinimumLc(
+  useCase: UseCase,
+  fontSize: number,
+  fontWeight: FontWeight
+): number {
+  // If use case is explicitly set to something other than body-text,
+  // use that threshold directly
+  if (useCase !== 'body-text') {
+    return USE_CASE_THRESHOLDS[useCase];
+  }
+
+  // For body text, adjust based on font size and weight
+  const isLarge = fontSize >= 24;
+  const isBold = fontWeight === 'bold';
+
+  if (isLarge || isBold) {
+    return 60; // Large or bold text can use lower contrast
+  }
+
+  return 75; // Standard body text
+}
+
+/**
+ * Get rating based on absolute Lc value
+ */
+function getRating(lcAbsolute: number): 'AAA' | 'AA' | 'A' | 'fail' {
+  if (lcAbsolute >= 90) return 'AAA';
+  if (lcAbsolute >= 75) return 'AA';
+  if (lcAbsolute >= 60) return 'A';
+  return 'fail';
+}
+
+/**
+ * Generate a recommendation for improving contrast
+ */
+function getRecommendation(
+  passes: boolean,
+  lcAbsolute: number,
+  minimumLc: number,
+  useCase: UseCase
+): string | null {
+  if (passes) return null;
+
+  const deficit = minimumLc - lcAbsolute;
+
+  if (lcAbsolute < 15) {
+    return `Contrast is too low for any text use. Current Lc: ${lcAbsolute.toFixed(1)}, need at least ${minimumLc} for ${useCase}.`;
+  }
+
+  if (lcAbsolute < 45) {
+    return `Only suitable for decorative or non-essential elements. Increase contrast by ~${deficit.toFixed(0)} Lc points for ${useCase}.`;
+  }
+
+  return `Increase contrast by ~${deficit.toFixed(0)} Lc points. Try darkening the text or lightening the background (or vice versa for dark mode).`;
+}
+
+/**
+ * Check contrast between foreground and background colors using APCA
+ *
+ * @param foreground - Text/foreground color (hex, rgb, hsl, or named color)
+ * @param background - Background color (hex, rgb, hsl, or named color)
+ * @param options - Font size, weight, and use case
+ * @returns ContrastResult with Lc value and pass/fail status
+ */
+export function checkContrast(
+  foreground: string,
+  background: string,
+  options: {
+    fontSize?: number;
+    fontWeight?: FontWeight;
+    useCase?: UseCase;
+  } = {}
+): ContrastResult {
+  const {
+    fontSize = 16,
+    fontWeight = 'normal',
+    useCase = 'body-text',
+  } = options;
+
+  // Calculate APCA contrast
+  // calcAPCA returns signed Lc: positive = dark on light, negative = light on dark
+  const lc = calcAPCA(foreground, background) as number;
+  const lcAbsolute = Math.abs(lc);
+  const polarity: 'dark-on-light' | 'light-on-dark' =
+    lc >= 0 ? 'dark-on-light' : 'light-on-dark';
+
+  // Determine minimum threshold
+  const minimumLc = getMinimumLc(useCase, fontSize, fontWeight);
+
+  // Check if it passes
+  const passes = lcAbsolute >= minimumLc;
+
+  // Get rating and recommendation
+  const rating = getRating(lcAbsolute);
+  const recommendation = getRecommendation(
+    passes,
+    lcAbsolute,
+    minimumLc,
+    useCase
+  );
+
+  return {
+    lc: Math.round(lc * 10) / 10, // Round to 1 decimal
+    lcAbsolute: Math.round(lcAbsolute * 10) / 10,
+    passes,
+    minimumLc,
+    polarity,
+    recommendation,
+    rating,
+  };
+}


### PR DESCRIPTION
## Summary
- Add APCA contrast checking via apca-w3 library
- Support multiple color formats (hex, rgb, hsl, named colors)
- Implement use-case thresholds (body-text: 75, large-text: 60, etc.)
- Adjust thresholds based on font size and weight
- Return Lc value, pass/fail, rating (AAA/AA/A/fail), and recommendations

## Test plan
- [x] Unit tests for contrast calculations (27 tests passing)
- [x] Test various color formats (hex, rgb, named)
- [x] Verify use-case thresholds
- [x] MCP server connects successfully

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)